### PR TITLE
feat: GitHub repository setup automation and Apache-2.0 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,25 @@ goossify ready --github-token ghp_xxxxxxxxxxxx .
 goossify ready .
 ```
 
-### 5. **Go Public** 🌍
+### 5. **Setup GitHub Repository Settings** ⚙️
+
+```bash
+# Automatically setup branch protection and repository settings
+export GITHUB_TOKEN=ghp_xxxxxxxxxxxx
+goossify github setup
+
+# Preview settings without applying (dry-run)
+goossify github setup --dry-run
+
+# Uses .goossify.yml configuration:
+# - Branch protection (main branch)
+# - Required reviews (configurable)
+# - Status checks (test, lint, etc.)
+# - Auto-delete branches after merge
+# - Labels setup
+```
+
+### 6. **Go Public** 🌍
 
 - Change GitHub repository to **Public**
 - Create initial release tag
@@ -210,6 +228,41 @@ goossify ready --github-token TOKEN .     # Include GitHub settings check
 - 📜 License Consistency
 - 🐙 GitHub Configuration (optional)
 
+### `goossify github setup` ✅
+Automatically configure GitHub repository settings
+
+```bash
+# Setup using .goossify.yml configuration
+export GITHUB_TOKEN=ghp_xxxxxxxxxxxx
+goossify github setup
+
+# Preview settings (dry-run mode)
+goossify github setup --dry-run
+
+# With explicit token
+goossify github setup --token ghp_xxxxxxxxxxxx
+```
+
+**Configured Settings:**
+- 🛡️ **Branch Protection** (main branch)
+  - Required status checks (test, lint, security, etc.)
+  - Required pull request reviews
+  - Dismiss stale reviews
+- 🏷️ **Repository Labels** (standardized labels for issues/PRs)
+- ⚙️ **Repository Settings**
+  - Auto-delete branches after merge
+  - Other repository preferences
+
+**Configuration File (.goossify.yml):**
+```yaml
+integrations:
+  github:
+    branch_protection: true
+    required_reviews: 2
+    status_checks: ["test", "lint", "security"]
+    delete_branch_on_merge: true
+```
+
 ### `goossify create` 🚧
 Create new projects from templates (Planned)
 
@@ -224,8 +277,8 @@ goossify create --template library my-lib
 |---------|--------|-------------|
 | 🏗️ `ossify` | ✅ **Complete** | Convert existing projects to OSS |
 | 📊 `status` | ✅ **Complete** | Health analysis & scoring |
-| 🚀 `ready` | ✅ **Complete** | Public release readiness check |
-| 🐙 GitHub Integration | ✅ **Complete** | Branch protection, settings analysis |
+| 🚀 `ready` | ✅ **Complete** | Pre-publication checklist |
+| 🐙 `github setup` | ✅ **Complete** | Auto-configure repository settings |
 | 🔧 `create` | 🚧 **Planned** | Template-based project creation |
 | 🎯 `init` | 🚧 **Planned** | Interactive project initialization |
 | 📈 `release` | 🚧 **Planned** | Automated release management |

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -44,7 +44,7 @@ func init() {
 	createCmd.Flags().StringVarP(&createTemplate, "template", "t", "", "使用するテンプレート (cli-tool|library|web-api|service)")
 	createCmd.Flags().StringVarP(&createAuthor, "author", "a", "", "作成者名")
 	createCmd.Flags().StringVarP(&createEmail, "email", "e", "", "作成者メールアドレス")
-	createCmd.Flags().StringVarP(&createLicense, "license", "l", "MIT", "ライセンス")
+	createCmd.Flags().StringVarP(&createLicense, "license", "l", "Apache-2.0", "ライセンス")
 	createCmd.Flags().StringVarP(&createGithub, "github", "g", "", "GitHubユーザー名")
 	createCmd.Flags().BoolVarP(&createInteractive, "interactive", "i", false, "対話的モードで設定")
 
@@ -112,7 +112,7 @@ func needsInteractiveInput(config *generator.ProjectConfig) bool {
 
 func setDefaultValues(config *generator.ProjectConfig) {
 	if config.License == "" {
-		config.License = "MIT"
+		config.License = "Apache-2.0"
 	}
 	if config.GitHubUsername == "" {
 		config.GitHubUsername = "your-username"

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/pigeonworks-llc/goossify/internal/github"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -35,15 +37,6 @@ var githubSetupCmd = &cobra.Command{
 }
 
 func runGitHubSetup(cmd *cobra.Command, args []string) error {
-	// GitHub token確認
-	token := githubToken
-	if token == "" {
-		token = os.Getenv("GITHUB_TOKEN")
-	}
-	if token == "" {
-		return fmt.Errorf("GitHub token が必要です。--token フラグか GITHUB_TOKEN 環境変数を設定してください")
-	}
-
 	// Git remote URLからowner/repo取得
 	owner, repo, err := getRepositoryInfo()
 	if err != nil {
@@ -52,9 +45,28 @@ func runGitHubSetup(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("🔧 GitHub リポジトリ設定を開始します: %s/%s\n", owner, repo)
 
+	// .goossify.yml から設定を読み込み
+	settings, err := loadGitHubSettings()
+	if err != nil {
+		fmt.Printf("⚠️  .goossify.yml の読み込みに失敗しました。デフォルト設定を使用します: %v\n", err)
+		settings = getDefaultSettings()
+	} else {
+		fmt.Println("✅ .goossify.yml から設定を読み込みました")
+	}
+
 	if dryRun {
-		fmt.Println("🔍 ドライランモード: 実際の設定は行いません")
+		fmt.Println("\n🔍 ドライランモード: 以下の設定を適用します（実際の変更は行いません）")
+		printSettings(settings)
 		return nil
+	}
+
+	// GitHub token確認（dry-runでない場合のみ）
+	token := githubToken
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	if token == "" {
+		return fmt.Errorf("GitHub token が必要です。--token フラグか GITHUB_TOKEN 環境変数を設定してください")
 	}
 
 	// GitHub クライアント作成
@@ -67,8 +79,69 @@ func runGitHubSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("GitHub クライアント作成失敗: %w", err)
 	}
 
-	// デフォルト設定で実行
-	settings := github.RepositorySettings{
+	// 設定実行
+	fmt.Println("\n📋 設定を適用中...")
+	if err := client.SetupRepository(settings); err != nil {
+		return fmt.Errorf("リポジトリ設定失敗: %w", err)
+	}
+
+	fmt.Println("✅ GitHub リポジトリ設定が完了しました")
+	fmt.Println("\n設定内容:")
+	printSettings(settings)
+	return nil
+}
+
+// loadGitHubSettings は .goossify.yml から GitHub 設定を読み込む
+func loadGitHubSettings() (*github.RepositorySettings, error) {
+	configPath := filepath.Join(".", ".goossify.yml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf(".goossify.yml が見つかりません")
+	}
+
+	v := viper.New()
+	v.SetConfigFile(configPath)
+	v.SetConfigType("yaml")
+
+	if err := v.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("設定ファイル読み込み失敗: %w", err)
+	}
+
+	// GitHub設定を読み込み
+	branchProtection := v.GetBool("integrations.github.branch_protection")
+	requiredReviews := v.GetInt("integrations.github.required_reviews")
+	statusChecks := v.GetStringSlice("integrations.github.status_checks")
+	deleteBranchOnMerge := v.GetBool("integrations.github.delete_branch_on_merge")
+
+	// デフォルト値
+	if requiredReviews == 0 {
+		requiredReviews = 1
+	}
+	if len(statusChecks) == 0 {
+		statusChecks = []string{"test", "lint"}
+	}
+
+	settings := &github.RepositorySettings{
+		Labels:              github.GetDefaultLabels(),
+		DeleteBranchOnMerge: deleteBranchOnMerge,
+	}
+
+	if branchProtection {
+		settings.BranchProtection = github.BranchProtectionSettings{
+			Branch:                  "main",
+			RequiredStatusChecks:    statusChecks,
+			RequiredReviews:         requiredReviews,
+			DismissStaleReviews:     true,
+			RequireCodeOwnerReviews: false,
+			RestrictPushes:          false,
+		}
+	}
+
+	return settings, nil
+}
+
+// getDefaultSettings はデフォルトの GitHub 設定を返す
+func getDefaultSettings() *github.RepositorySettings {
+	return &github.RepositorySettings{
 		BranchProtection: github.BranchProtectionSettings{
 			Branch:                  "main",
 			RequiredStatusChecks:    []string{"test", "lint"},
@@ -80,13 +153,21 @@ func runGitHubSetup(cmd *cobra.Command, args []string) error {
 		Labels:              github.GetDefaultLabels(),
 		DeleteBranchOnMerge: true,
 	}
+}
 
-	if err := client.SetupRepository(&settings); err != nil {
-		return fmt.Errorf("リポジトリ設定失敗: %w", err)
+// printSettings は設定内容を表示
+func printSettings(settings *github.RepositorySettings) {
+	fmt.Println("  📌 ブランチ保護:")
+	if settings.BranchProtection.Branch != "" {
+		fmt.Printf("     - ブランチ: %s\n", settings.BranchProtection.Branch)
+		fmt.Printf("     - 必須レビュー数: %d\n", settings.BranchProtection.RequiredReviews)
+		fmt.Printf("     - 必須ステータスチェック: %v\n", settings.BranchProtection.RequiredStatusChecks)
+		fmt.Printf("     - 古いレビューの却下: %v\n", settings.BranchProtection.DismissStaleReviews)
+	} else {
+		fmt.Println("     - 無効")
 	}
-
-	fmt.Println("✅ GitHub リポジトリ設定が完了しました")
-	return nil
+	fmt.Printf("  🏷️  ラベル数: %d\n", len(settings.Labels))
+	fmt.Printf("  🗑️  マージ後のブランチ削除: %v\n", settings.DeleteBranchOnMerge)
 }
 
 func getRepositoryInfo() (owner, repo string, err error) {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -66,7 +66,7 @@ func init() {
 	initCmd.Flags().StringVar(&templateName, "template", "", "使用するテンプレート名")
 	initCmd.Flags().StringVarP(&author, "author", "a", "", "作成者名")
 	initCmd.Flags().StringVarP(&email, "email", "e", "", "作成者メールアドレス")
-	initCmd.Flags().StringVarP(&license, "license", "l", "MIT", "ライセンス")
+	initCmd.Flags().StringVarP(&license, "license", "l", "Apache-2.0", "ライセンス")
 	initCmd.Flags().StringVarP(&githubUsername, "github", "g", "", "GitHubユーザー名")
 }
 
@@ -134,7 +134,7 @@ func collectProjectConfig(projectName string) (*generator.ProjectConfig, error) 
 	}
 
 	if config.License == "" {
-		config.License = "MIT"
+		config.License = "Apache-2.0"
 	}
 
 	if config.GitHubUsername == "" {
@@ -267,14 +267,14 @@ func promptGitHubUsername(reader *bufio.Reader, config *generator.ProjectConfig)
 
 func promptLicense(reader *bufio.Reader, config *generator.ProjectConfig) error {
 	if config.License == "" {
-		fmt.Print("ライセンス (MIT): ")
+		fmt.Print("ライセンス (Apache-2.0): ")
 		licenseType, err := reader.ReadString('\n')
 		if err != nil {
 			return err
 		}
 		license := strings.TrimSpace(licenseType)
 		if license == "" {
-			license = "MIT"
+			license = "Apache-2.0"
 		}
 		config.License = license
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -338,7 +338,7 @@ func (g *Generator) getLicenseTemplate() string {
 	case "BSD-3-Clause":
 		return templates.BSD3LicenseTemplate
 	default:
-		return templates.MITLicenseTemplate
+		return templates.Apache2LicenseTemplate
 	}
 }
 

--- a/internal/ossify/ossify.go
+++ b/internal/ossify/ossify.go
@@ -75,27 +75,23 @@ func (o *Ossifier) ensureLicense() error {
 	}
 
 	fmt.Println("📄 LICENSE ファイルを生成中...")
-	licenseContent := fmt.Sprintf(`MIT License
+	licenseContent := fmt.Sprintf(`Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-Copyright (c) %d Pigeon Works LLC
+Copyright %d Pigeon Works LLC
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.`, time.Now().Year())
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.`, time.Now().Year())
 
 	return os.WriteFile(licensePath, []byte(licenseContent), 0600)
 }
@@ -267,7 +263,7 @@ By participating, you are expected to uphold this code. Please report unacceptab
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.`, o.projectName, o.projectName, o.projectName)
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0.`, o.projectName, o.projectName, o.projectName)
 
 		if err := os.WriteFile(contributingPath, []byte(contributingContent), 0600); err != nil {
 			return fmt.Errorf("CONTRIBUTING.md作成失敗: %w", err)


### PR DESCRIPTION
## Summary

- Enhance `github setup` command to read configuration from `.goossify.yml`
- Add dry-run mode for previewing settings without applying
- Change default license from MIT to Apache-2.0 across all commands
- Update documentation with GitHub setup workflow

## Changes

### GitHub Setup Enhancement
- `cmd/github.go`: Read settings from `.goossify.yml` using Viper
- `cmd/github.go`: Add `loadGitHubSettings()` to parse YAML configuration
- `cmd/github.go`: Move token validation after dry-run check
- `cmd/github.go`: Add `printSettings()` for configuration display
- `README.md`: Document GitHub setup command and workflow

### License Change
- `cmd/create.go`: Change default license flag from MIT to Apache-2.0
- `cmd/init.go`: Change default license flag and prompt to Apache-2.0
- `internal/generator/generator.go`: Change default license template to Apache-2.0
- `internal/ossify/ossify.go`: Use Apache 2.0 license template in generated files

## Configuration Example

\`.goossify.yml\`:
\`\`\`yaml
integrations:
  github:
    branch_protection: true
    required_reviews: 2
    status_checks: ["test", "lint", "security"]
    delete_branch_on_merge: true
\`\`\`

## Testing

- ✅ Build successful
- ✅ All tests passing
- ✅ Tested create command with Apache-2.0 license generation
- ✅ Dry-run mode works without GitHub token