### PR TITLE
feat: allow admins to bypass branch protection for self-merge

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -154,7 +154,7 @@ func (c *Client) setupBranchProtection(config BranchProtectionSettings) error {
 			RequireCodeOwnerReviews:      config.RequireCodeOwnerReviews,
 			RequiredApprovingReviewCount: config.RequiredReviews,
 		},
-		EnforceAdmins: true,
+		EnforceAdmins: false,
 	}
 
 	if config.RestrictPushes {


### PR DESCRIPTION
## Summary

Change `EnforceAdmins` from `true` to `false` in branch protection settings to allow repository admins to merge PRs without requiring approval reviews.

## Changes

- `internal/github/client.go`: Set `EnforceAdmins: false` in `setupBranchProtection()`

## Motivation

For personal projects and small teams, requiring admins to get approval reviews creates unnecessary friction. With this change:

- ✅ Admins can self-merge PRs after CI passes
- ✅ Non-admin contributors still require 1 approval review
- ✅ All contributors must pass required status checks (test, lint)

## Testing

- ✅ Applied settings with `goossify github setup`
- ✅ Verified with GitHub API: `enforce_admins: false`